### PR TITLE
Retry 429 errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.13
 require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 )

--- a/go.sum
+++ b/go.sum
@@ -450,6 +450,7 @@ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20191024005414-555d28b269f0 h1:/5xXl8Y5W96D+TtHSlonuFqGHIWVuyCkGJLwGh9JJFs=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/internal/powerbi/resource_pbix_test.go
+++ b/internal/powerbi/resource_pbix_test.go
@@ -138,7 +138,7 @@ func TestAccPBIX_parameters(t *testing.T) {
 			// identical resource definition with parameter state drift
 			{
 				PreConfig: func() {
-					//update paramter outside of terraform to simulate drift
+					//update parameter outside of terraform to simulate drift
 					client := testAccProvider.Meta().(*powerbiapi.Client)
 					client.UpdateParametersInGroup(groupID, datasetID, powerbiapi.UpdateParametersInGroupRequest{
 						UpdateDetails: []powerbiapi.UpdateParametersInGroupRequestItem{

--- a/internal/powerbiapi/client_error.go
+++ b/internal/powerbiapi/client_error.go
@@ -20,13 +20,13 @@ type ErrorResponse struct {
 	Error ErrorBody
 }
 
-// ErrorBody represents the error returend in the body of Power BI API requests
+// ErrorBody represents the error returned in the body of Power BI API requests
 type ErrorBody struct {
 	Code    string
 	Message string
 }
 
-type roundTripperErrorOnUnsuccessful struct {
+type errorOnUnsuccessfulRoundTripper struct {
 	innerRoundTripper http.RoundTripper
 }
 
@@ -39,7 +39,13 @@ func (err HTTPUnsuccessfulError) Error() string {
 	return message
 }
 
-func (h roundTripperErrorOnUnsuccessful) RoundTrip(req *http.Request) (*http.Response, error) {
+func newErrorOnUnsuccessfulRoundTripper(next http.RoundTripper) http.RoundTripper {
+	return &errorOnUnsuccessfulRoundTripper{
+		innerRoundTripper: next,
+	}
+}
+
+func (h *errorOnUnsuccessfulRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	resp, err := h.innerRoundTripper.RoundTrip(req)
 

--- a/internal/powerbiapi/client_retry.go
+++ b/internal/powerbiapi/client_retry.go
@@ -1,0 +1,62 @@
+package powerbiapi
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+type retryTooManyRequestsRoundTripper struct {
+	innerRoundTripper http.RoundTripper
+}
+
+func newRetryTooManyRequestsRoundTripper(next http.RoundTripper) http.RoundTripper {
+	return &retryTooManyRequestsRoundTripper{
+		innerRoundTripper: next,
+	}
+}
+
+func (rt *retryTooManyRequestsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+
+	resp, err := rt.innerRoundTripper.RoundTrip(req)
+
+retry:
+	for attempts := 1; err == nil && resp.StatusCode == 429; attempts++ {
+		switch attempts {
+		case 1:
+			// retry immediately. PowerBI API typically responds successfully on a retry
+			break
+		case 2:
+			// if failed again then we will respect the retry-after header
+			// these can unfortunately be anywhere up to a minute
+			time.Sleep(readRetryAfter(resp, 5*time.Second))
+		case 3:
+			// respect retry-after again
+			time.Sleep(readRetryAfter(resp, 10*time.Second))
+		default:
+			// we have retried enough
+			break retry
+		}
+
+		resp, err = rt.innerRoundTripper.RoundTrip(req)
+	}
+
+	return resp, err
+}
+
+func readRetryAfter(resp *http.Response, fallback time.Duration) time.Duration {
+	waitSeconds, parseErr := extractHeaderAsInteger(resp, "Retry-After")
+	if parseErr != nil {
+		return fallback
+	}
+	return time.Duration(waitSeconds+1) * time.Second
+}
+
+func extractHeaderAsInteger(resp *http.Response, key string) (int, error) {
+	headerValues, ok := resp.Header[key]
+	if !ok || len(headerValues) == 0 {
+		return 0, fmt.Errorf("Response does not contain key '%s'", key)
+	}
+	return strconv.Atoi(headerValues[0])
+}


### PR DESCRIPTION
Test cases often get 429 errors. This will make them more resiliant. Should also help any providers that have lots of resources