### PR TITLE
Fix get capacities with capacities admins set

### DIFF
--- a/internal/powerbiapi/capacities.go
+++ b/internal/powerbiapi/capacities.go
@@ -27,9 +27,7 @@ type GetCapacitiesResponseItem struct {
 }
 
 //CapacityAdmins represents the list of capacity admins.
-type CapacityAdmins struct {
-	string
-}
+type CapacityAdmins string
 
 // GroupAssignToCapacity assigns capcity to a workspace
 func (client *Client) GroupAssignToCapacity(groupID string, request GroupAssignToCapacityRequest) error {


### PR DESCRIPTION
When trying to assign to capacity that has admins apply and acceptance tests fails with following error:
`json: cannot unmarshal string into Go struct field GetCapacitiesResponseItem.Value.Admins of type powerbiapi.CapacityAdmin`

It happens, because `CapacityAdmins` defined as a struct instead of string. [Documentation](https://docs.microsoft.com/en-us/rest/api/power-bi/capacities/getcapacities#capacity) says that `admins` is `string[]`.
Sample JSON response (with my comments):
```JSON
{
    "@odata.context": "http://wabi-us-central-a-primary-redirect.analysis.windows.net/v1.0/myorg/$metadata#capacities",
    "value": [
        {
           // Capacity crated via https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/powerbi_embedded
            "id": "<SKIP>",
            "displayName": "<name>",
            "admins": [
               // List of admins is just array of strings
                "<SPN OR APP_GUIB HERE>",
                "<EMAIL>"
            ],
            "sku": "A4",
            "state": "Active",
            "capacityUserAccessRight": "Admin",
            "region": "East US"
        },
        // Shared capacity (no admins)
        {
            "id": "<SKIP>",
            "displayName": "Premium Per User - Reserved",
            "admins": [],
            "sku": "PP3",
            "state": "Active",
            "capacityUserAccessRight": "Assign",
            "region": "Central US"
        }
    ]
}
``` 

This PR fixes that issue.
