### PR TITLE
powerbi_capacity data source

### DIFF
--- a/docs/data-sources/capacity.md
+++ b/docs/data-sources/capacity.md
@@ -1,0 +1,34 @@
+# Capacity Data Source
+`powerbi_capacity` represents a capacity within Power BI.
+Capacity could be created in three different ways:
+* Reserved Premium Per user Capacity - created by Power BI service
+* Power BI Embedded - Azure resource could be created via Azure Portal, `az` command line or https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/powerbi_embedded
+* Power BI Premium - purchased via Microsoft 365
+
+
+## Example Usage
+```hcl
+data "powerbi_capacity" "mycapacity" {
+  name = "Sample capacity"
+}
+
+output mycapacity_id {
+  value = data.powerbi_capacity.mycapacity.id
+}
+```
+
+
+
+## Argument Reference
+#### The following arguments are supported:
+<!-- docgen:NonComputedParameters -->
+* `name` - (Required) Name of the capacity.
+<!-- /docgen -->
+
+## Attributes Reference
+#### The following attributes are exported in addition to the arguments listed above:
+* `id` - The ID of the capacity.
+<!-- docgen:ComputedParameters -->
+* `region` - (Optional) Region of the capacity.
+* `sku` - (Optional) SKU of the capacity.
+<!-- /docgen -->

--- a/internal/powerbi/data_source_capacity.go
+++ b/internal/powerbi/data_source_capacity.go
@@ -1,0 +1,63 @@
+package powerbi
+
+import (
+	"fmt"
+
+	"github.com/codecutout/terraform-provider-powerbi/internal/powerbiapi"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// DataSourceCapacity represents a Power BI capacity
+func DataSourceCapacity() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceCapacityRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the capacity.",
+			},
+			"sku": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "SKU of the capacity",
+			},
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Region of the capacity.",
+			},
+		},
+	}
+}
+
+func dataSourceCapacityRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*powerbiapi.Client)
+	name := d.Get("name").(string)
+	capacityList, err := client.GetCapacities()
+	if err != nil {
+		return err
+	}
+	var capacityObjFound bool
+	var capacityObj powerbiapi.GetCapacitiesResponseItem
+	if len(capacityList.Value) >= 1 {
+		for _, capacityObj = range capacityList.Value {
+			if capacityObj.DisplayName == name {
+				capacityObjFound = true
+			}
+		}
+	}
+	if capacityObjFound != true {
+		return fmt.Errorf("Capacity %s not found or logged-in user doesn't have capacity admin rights", name)
+	}
+
+	d.SetId(capacityObj.ID)
+	d.Set("name", capacityObj.DisplayName)
+	d.Set("sku", capacityObj.SKU)
+	d.Set("region", capacityObj.Region)
+
+	return nil
+}

--- a/internal/powerbi/data_source_capacity_test.go
+++ b/internal/powerbi/data_source_capacity_test.go
@@ -1,0 +1,32 @@
+package powerbi
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceCapacity_basic(t *testing.T) {
+	var capacityName = "Premium Per User - Reserved" // Using Capacity that always exists
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				data "powerbi_capacity" "test" {
+					name = "%s"
+				}
+				`, capacityName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.powerbi_capacity.test", "name", capacityName),
+					resource.TestCheckResourceAttrSet("data.powerbi_capacity.test", "id"),
+					resource.TestCheckResourceAttrSet("data.powerbi_capacity.test", "sku"),
+					resource.TestCheckResourceAttrSet("data.powerbi_capacity.test", "region"),
+				),
+			},
+		},
+	})
+}

--- a/internal/powerbi/provider.go
+++ b/internal/powerbi/provider.go
@@ -53,6 +53,7 @@ func Provider() *schema.Provider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"powerbi_workspace": DataSourceWorkspace(),
+			"powerbi_capacity":  DataSourceCapacity(),
 		},
 
 		ConfigureFunc: providerConfigure,


### PR DESCRIPTION
The PR capacity data_source.

Workspace assigned to Premium capacity needs to know Capacity Id. We have 3 ways to how capacity could be created:
* Reserved Premium Per user Capacity - created by Power BI service. should always exist
* Power BI Embedded - Azure resource could be created via Azure Portal, `az` command line or https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/powerbi_embedded
* Power BI Premium - purchased via Microsoft 365

`powerbi_capacity` datasource allows to get Id (or other properties) by name and then use it with `powerbi_workspace` resource

Tests:
```
go test -v ./internal/powerbi/ -run=TestAccDataSourceCapacity_basic
=== RUN   TestAccDataSourceCapacity_basic
--- PASS: TestAccDataSourceCapacity_basic (15.67s)
PASS
ok      github.com/codecutout/terraform-provider-powerbi/internal/powerbi       15.949s
```

Additional tests that could be added include:
* Create PBI Embedded using `powerbi_embedded` resource, however it will take ~20-30 minutes and cost money on each test run
* `powerbi_workspace` tests could be using data source to get Id
