### PR TITLE
Add rebind report to dataset functionality

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       fail-fast: false
-      max-parallel: 2 #limits on the PowerBI API can Too Many Request errors in the tests
+      max-parallel: 1 #limits on the PowerBI API can Too Many Request errors in the tests
       matrix:
 
         # list whatever Terraform versions here you would like to support

--- a/docs/resources/pbix.md
+++ b/docs/resources/pbix.md
@@ -63,12 +63,11 @@ resource "powerbi_pbix" "example_dataset" {
 
 # ... and then connect it to a report
 resource "powerbi_pbix" "example_report" {
-  workspace_id = powerbi_workspace.example.id
-  name         = "My report"
-  source       = "data/Reports/Report.pbix"
-  source_hash  = filemd5("data/Reports/Report.pbix")
-  dataset_id   = powerbi_pbix.example_dataset.dataset_id # Bind the report to the dataset
-  skip_dataset = true                                    # Only manage the report (this is required for the delete operation)
+  workspace_id      = powerbi_workspace.example.id
+  name              = "My report"
+  source            = "data/Reports/Report.pbix"
+  source_hash       = filemd5("data/Reports/Report.pbix")
+  rebind_dataset_id = powerbi_pbix.example_dataset.dataset_id # Bind the report to the dataset
 }
 
 # add more reports here and bind them to the same dataset
@@ -84,14 +83,13 @@ resource "powerbi_pbix" "example_report" {
 * `source` - (Required) An absolute path to a PBIX file on the local system.
 * `datasource` - (Optional) Datasources to be reconfigured after deploying the PBIX dataset. Changing this value will require reuploading the PBIX. Any datasource updated will not be tracked. A [`datasource`](#a-datasource-block-supports-the-following) block is defined below.
 * `parameter` - (Optional) Parameters to be configured on the PBIX dataset. These can be updated without requiring reuploading the PBIX. Any parameters not mentioned will not be tracked or updated. A [`parameter`](#a-parameter-block-supports-the-following) block is defined below.
-* `skip_dataset` - (Optional, Default: `false`) If true only the PBIX report is managed by the resource. Only useful if `dataset_id` is provided.
-* `skip_report` - (Optional, Default: `false`) If true only the PBIX dataset is deployed.
+* `rebind_dataset_id` - (Optional) If set, will rebind the report to the the specified dataset ID.
+* `skip_report` - (Optional, Default: `false`) If true, only the PBIX dataset is deployed.
 * `source_hash` - (Optional) Used to trigger updates. The only meaningful value is `${filemd5("path/to/file")}`.
 
 ---
 
-### A `datasource` block supports the following
-
+#### A `datasource` block supports the following:
 * `database` - (Optional) The database name, if applicable for the type of datasource.
 * `original_database` - (Optional) The database name as configured in the PBIX, if applicable for the type of datasource This will be the value replaced with the value in the 'databsase' field.
 * `original_server` - (Optional) The server name as configured in the PBIX, if applicable for the type of datasource. This will be the value replaced with the value in the 'server' field.
@@ -102,8 +100,7 @@ resource "powerbi_pbix" "example_report" {
 
 ---
 
-### A `parameter` block supports the following
-
+#### A `parameter` block supports the following:
 * `name` - (Required) The parameter name.
 * `value` - (Required) The parameter value.
 <!-- /docgen -->
@@ -114,6 +111,6 @@ resource "powerbi_pbix" "example_report" {
 
 * `id` - The ID of the import.
 <!-- docgen:ComputedParameters -->
-* `dataset_id` - (Optional) The ID for the dataset that was deployed as part of the PBIX.
-* `report_id` - (Optional) The ID for the report that was deployed as part of the PBIX.
+* `dataset_id` - The ID for the dataset that was deployed as part of the PBIX.
+* `report_id` - The ID for the report that was deployed as part of the PBIX.
 <!-- /docgen -->

--- a/docs/resources/pbix.md
+++ b/docs/resources/pbix.md
@@ -1,7 +1,9 @@
 # PBIX Resource
-`powerbi_pbix` represents a PBIX upload in Power BI. 
+
+`powerbi_pbix` represents a PBIX upload in Power BI.
 
 Although from the user perspective this is a single resource, internally a PBIX upload generates the following
+
 * Import object - identified with `id`
 * Dataset object - identified with `dataset_id`
 * Report object - identified with `report_id`
@@ -9,6 +11,7 @@ Although from the user perspective this is a single resource, internally a PBIX 
 ## Example Usage
 
 ### Datasource
+
 ```hcl
 resource "powerbi_pbix" "mypbix" {
   workspace_id = "470b0d57-1f23-4332-a16f-9235bd174318"
@@ -23,8 +26,8 @@ resource "powerbi_pbix" "mypbix" {
 }
 ```
 
-
 ### Parameters
+
 ```hcl
 resource "powerbi_pbix" "mypbix" {
   workspace_id = "470b0d57-1f23-4332-a16f-9235bd174318"
@@ -41,20 +44,54 @@ resource "powerbi_pbix" "mypbix" {
   }
 }
 ```
+
+### Separate dataset resource
+
+```hcl
+resource "powerbi_workspace" "example" {
+  name = "Example Workspace"
+}
+
+# Deploy the dataset first ...
+resource "powerbi_pbix" "example_dataset" {
+  workspace_id = powerbi_workspace.example.id
+  name         = "My dataset"
+  source       = "data/Datasets/Dataset.pbix"
+  source_hash  = filemd5("data/Datasets/Dataset.pbix")
+  skip_report  = true # Only deploy the dataset
+}
+
+# ... and then connect it to a report
+resource "powerbi_pbix" "example_report" {
+  workspace_id = powerbi_workspace.example.id
+  name         = "My report"
+  source       = "data/Reports/Report.pbix"
+  source_hash  = filemd5("data/Reports/Report.pbix")
+  dataset_id   = powerbi_pbix.example_dataset.dataset_id # Bind the report to the dataset
+  skip_dataset = true                                    # Only manage the report (this is required for the delete operation)
+}
+
+# add more reports here and bind them to the same dataset
+```
+
 ## Argument Reference
-#### The following arguments are supported:
+
+### The following arguments are supported
+
 <!-- docgen:NonComputedParameters -->
 * `name` - (Required, Forces new resource) Name of the PBIX. This will be used as the name for the report and dataset.
 * `workspace_id` - (Required, Forces new resource) Workspace ID in which the PBIX will be added.
 * `source` - (Required) An absolute path to a PBIX file on the local system.
 * `datasource` - (Optional) Datasources to be reconfigured after deploying the PBIX dataset. Changing this value will require reuploading the PBIX. Any datasource updated will not be tracked. A [`datasource`](#a-datasource-block-supports-the-following) block is defined below.
 * `parameter` - (Optional) Parameters to be configured on the PBIX dataset. These can be updated without requiring reuploading the PBIX. Any parameters not mentioned will not be tracked or updated. A [`parameter`](#a-parameter-block-supports-the-following) block is defined below.
+* `skip_dataset` - (Optional, Default: `false`) If true only the PBIX report is managed by the resource. Only useful if `dataset_id` is provided.
 * `skip_report` - (Optional, Default: `false`) If true only the PBIX dataset is deployed.
 * `source_hash` - (Optional) Used to trigger updates. The only meaningful value is `${filemd5("path/to/file")}`.
 
 ---
 
-#### A `datasource` block supports the following:
+### A `datasource` block supports the following
+
 * `database` - (Optional) The database name, if applicable for the type of datasource.
 * `original_database` - (Optional) The database name as configured in the PBIX, if applicable for the type of datasource This will be the value replaced with the value in the 'databsase' field.
 * `original_server` - (Optional) The server name as configured in the PBIX, if applicable for the type of datasource. This will be the value replaced with the value in the 'server' field.
@@ -65,13 +102,16 @@ resource "powerbi_pbix" "mypbix" {
 
 ---
 
-#### A `parameter` block supports the following:
+### A `parameter` block supports the following
+
 * `name` - (Required) The parameter name.
 * `value` - (Required) The parameter value.
 <!-- /docgen -->
 
 ## Attributes Reference
-#### The following attributes are exported in addition to the arguments listed above:
+
+### The following attributes are exported in addition to the arguments listed above
+
 * `id` - The ID of the import.
 <!-- docgen:ComputedParameters -->
 * `dataset_id` - (Optional) The ID for the dataset that was deployed as part of the PBIX.

--- a/internal/powerbiapi/client_retry_intermittent_error.go
+++ b/internal/powerbiapi/client_retry_intermittent_error.go
@@ -1,0 +1,41 @@
+package powerbiapi
+
+import (
+	"net/http"
+	"time"
+)
+
+type retryIntermittentErrorRoundTripper struct {
+	innerRoundTripper http.RoundTripper
+}
+
+func newRetryIntermittentErrorRoundTripper(next http.RoundTripper) http.RoundTripper {
+	return &retryIntermittentErrorRoundTripper{
+		innerRoundTripper: next,
+	}
+}
+
+func (rt *retryIntermittentErrorRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+
+	resp, err := rt.innerRoundTripper.RoundTrip(req)
+
+retry:
+	for attempts := 1; err == nil && resp.StatusCode == 500 || resp.StatusCode == 400; attempts++ {
+		switch attempts {
+		case 1:
+			// retry immediately. PowerBI API typically responds successfully on a retry
+			break
+		case 2:
+			// gives the service some time to recover
+			time.Sleep(5 * time.Second)
+			break
+		default:
+			// we have retried enough
+			break retry
+		}
+
+		resp, err = rt.innerRoundTripper.RoundTrip(req)
+	}
+
+	return resp, err
+}

--- a/internal/powerbiapi/reports.go
+++ b/internal/powerbiapi/reports.go
@@ -5,6 +5,11 @@ import (
 	"net/url"
 )
 
+// RebindReportInGroup represents the request for the RebindReportInGroup API
+type RebindReportInGroupRequest struct {
+	DatasetID string `json:"datasetId"`
+}
+
 // GetReportsInGroupResponse represents the details when getting a report in a group.
 type GetReportsInGroupResponse struct {
 	Value []GetReportsInGroupResponseItem
@@ -34,6 +39,15 @@ func (client *Client) DeleteReportInGroup(groupID string, reportID string) error
 
 	url := fmt.Sprintf("https://api.powerbi.com/v1.0/myorg/groups/%s/reports/%s", url.PathEscape(groupID), url.PathEscape(reportID))
 	err := client.doJSON("DELETE", url, nil, nil)
+
+	return err
+}
+
+// RebindReportInGroup rebinds the specified report from the specified group to the requested dataset.
+func (client *Client) RebindReportInGroup(groupID string, reportID string, request RebindReportInGroupRequest) error {
+
+	url := fmt.Sprintf("https://api.powerbi.com/v1.0/myorg/groups/%s/reports/%s/Rebind", url.PathEscape(groupID), url.PathEscape(reportID))
+	err := client.doJSON("POST", url, request, nil)
 
 	return err
 }

--- a/internal/powerbiapi/reports.go
+++ b/internal/powerbiapi/reports.go
@@ -24,11 +24,30 @@ type GetReportsInGroupResponseItem struct {
 	EmbedURL  string
 }
 
+// GetReportsInGroupResponse represents the details when getting a report in a group.
+type GetReportInGroupResponse struct {
+	ID        string
+	Name      string
+	DatasetID string
+	WebURL    string
+	EmbedURL  string
+}
+
 // GetReportsInGroup returns a list of reports within the specified group.
 func (client *Client) GetReportsInGroup(groupID string) (*GetReportsInGroupResponse, error) {
 
 	var respObj GetReportsInGroupResponse
 	url := fmt.Sprintf("https://api.powerbi.com/v1.0/myorg/groups/%s/reports", url.PathEscape(groupID))
+	err := client.doJSON("GET", url, nil, &respObj)
+
+	return &respObj, err
+}
+
+// GetReportInGroup returns a report that exists within a group
+func (client *Client) GetReportInGroup(groupID string, reportID string) (*GetReportInGroupResponse, error) {
+
+	var respObj GetReportInGroupResponse
+	url := fmt.Sprintf("https://api.powerbi.com/v1.0/myorg/groups/%s/reports/%s", url.PathEscape(groupID), url.PathEscape(reportID))
 	err := client.doJSON("GET", url, nil, &respObj)
 
 	return &respObj, err


### PR DESCRIPTION
## Introduction

We are very often in a situation where we want to to separate PowerBI datasets and reports into two different files, as the datasets are generic and are often reused by multiple reports. Currently, if we upload a report using this provider it is linked to the dataset it was last linked to for development purposes. We are then using some custom Powershell script to do the rebinding - however, that fails very often and terraform cannot manage the state of this rebinding operation. Thus, this PR will add proper rebinding functionality to the provider itself.

## Example code
```hcl
resource "powerbi_workspace" "example" {
  name = "Example Workspace"
}

# Deploy the dataset first ...
resource "powerbi_pbix" "example_dataset" {
  workspace_id = powerbi_workspace.example.id
  name         = "My dataset"
  source       = "data/Datasets/Dataset.pbix"
  source_hash  = filemd5("data/Datasets/Dataset.pbix")
  skip_report  = true # Only deploy the dataset
}

# ... and then connect it to a report
resource "powerbi_pbix" "example_report" {
  workspace_id = powerbi_workspace.example.id
  name         = "My report"
  source       = "data/Reports/Report.pbix"
  source_hash  = filemd5("data/Reports/Report.pbix")
  dataset_id   = powerbi_pbix.example_dataset.dataset_id # Bind the report to the dataset
  skip_dataset = true                                    # Only manage the report (this is required for the delete operation)
}

# add more reports here and bind them to the same dataset
```
Result in the portal is the following:
![image](https://user-images.githubusercontent.com/2057062/133924009-5e71b641-c27f-4df9-a299-f3ae7a70a5cd.png)

## Caveats
I needed to introduce an additional argument `skip_dataset` specifically for the delete operation. The reason is that if the dataset is managed by another resource (so a separate `powerbi_pbix` as in the example above), the delete operation should not delete the dataset connected to the report, as its state is managed by the other resource. It would be nice if there was a way to tell if a `Computed` attribute has indeed been computed or has been set by the configuration. Not sure if this is possible, as this is my first Go contribution.

## Testing
As this is my very first experiment with Go, I was not exactly able to make an acceptance test work, but I'm happy to help doing that, however, I will probably need to support to get started.

My manual tests went pretty good. I have tested the following:
- Running a clean apply
- Re-running apply (shows no changes)
- Removing the report (does not remove the dataset)
- Removing everything
- Adding the report first without the `dataset_id`, and adding the dataset in a following run
