### PR TITLE
Fix issue preventing pbix updates when rebinding

### DIFF
--- a/docs/resources/pbix.md
+++ b/docs/resources/pbix.md
@@ -113,4 +113,5 @@ resource "powerbi_pbix" "example_report" {
 <!-- docgen:ComputedParameters -->
 * `dataset_id` - The ID for the dataset that was deployed as part of the PBIX.
 * `report_id` - The ID for the report that was deployed as part of the PBIX.
+* `report_original_dataset_id` - The dataset to which the report that was deployed is pointing. This is primarily used to allow reverting rebinded datasets back to the original source.
 <!-- /docgen -->

--- a/internal/pbixrewriter/rewritePbix.go
+++ b/internal/pbixrewriter/rewritePbix.go
@@ -2,7 +2,6 @@ package pbixrewriter
 
 import (
 	"archive/zip"
-	"fmt"
 	"io"
 	"os"
 )
@@ -61,11 +60,10 @@ func buildWriterPipelineFunc(writer *zip.Writer) PipelineFunc {
 		if err != nil {
 			return err
 		}
-		x, err := io.Copy(outputItemWriter, reader)
+		_, err = io.Copy(outputItemWriter, reader)
 		if err != nil {
 			return err
 		}
-		fmt.Printf("%s written %d bytes\n", header.Name, x)
 		return nil
 	}
 }


### PR DESCRIPTION
Unbind before importing. This allows the import to correctly update the report instead of creating a new report