### PR TITLE
Capacity data source break

### DIFF
--- a/docs/data-sources/capacity.md
+++ b/docs/data-sources/capacity.md
@@ -1,0 +1,34 @@
+# Capacity Data Source
+`powerbi_capacity` represents a capacity within Power BI.
+Capacity could be created in three different ways:
+* Reserved Premium Per user Capacity - created by Power BI service
+* Power BI Embedded - Azure resource could be created via Azure Portal, `az` command line or https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/powerbi_embedded
+* Power BI Premium - purchased via Microsoft 365
+
+
+## Example Usage
+```hcl
+data "powerbi_capacity" "mycapacity" {
+  name = "Sample capacity"
+}
+
+output mycapacity_id {
+  value = data.powerbi_capacity.mycapacity.id
+}
+```
+
+
+
+## Argument Reference
+#### The following arguments are supported:
+<!-- docgen:NonComputedParameters -->
+* `name` - (Required) Name of the capacity.
+<!-- /docgen -->
+
+## Attributes Reference
+#### The following attributes are exported in addition to the arguments listed above:
+* `id` - The ID of the capacity.
+<!-- docgen:ComputedParameters -->
+* `region` - (Optional) Region of the capacity.
+* `sku` - (Optional) SKU of the capacity.
+<!-- /docgen -->

--- a/internal/powerbi/data_source_capacity.go
+++ b/internal/powerbi/data_source_capacity.go
@@ -1,0 +1,63 @@
+package powerbi
+
+import (
+	"fmt"
+
+	"github.com/codecutout/terraform-provider-powerbi/internal/powerbiapi"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+// DataSourceCapacity represents a Power BI capacity
+func DataSourceCapacity() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceCapacityRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the capacity.",
+			},
+			"sku": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "SKU of the capacity",
+			},
+			"region": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Region of the capacity.",
+			},
+		},
+	}
+}
+
+func dataSourceCapacityRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*powerbiapi.Client)
+	name := d.Get("name").(string)
+	capacityList, err := client.GetCapacities()
+	if err != nil {
+		return err
+	}
+	var capacityObjFound bool
+	var capacityObj powerbiapi.GetCapacitiesResponseItem
+	if len(capacityList.Value) >= 1 {
+		for _, capacityObj = range capacityList.Value {
+			if capacityObj.DisplayName == name {
+				capacityObjFound = true
+			}
+		}
+	}
+	if capacityObjFound != true {
+		return fmt.Errorf("Capacity %s not found or logged-in user doesn't have capacity admin rights", name)
+	}
+
+	d.SetId(capacityObj.ID)
+	d.Set("name", capacityObj.DisplayName)
+	d.Set("sku", capacityObj.SKU)
+	d.Set("region", capacityObj.Region)
+
+	return nil
+}

--- a/internal/powerbi/data_source_capacity.go
+++ b/internal/powerbi/data_source_capacity.go
@@ -47,6 +47,7 @@ func dataSourceCapacityRead(d *schema.ResourceData, meta interface{}) error {
 		for _, capacityObj = range capacityList.Value {
 			if capacityObj.DisplayName == name {
 				capacityObjFound = true
+				break
 			}
 		}
 	}

--- a/internal/powerbi/data_source_capacity_test.go
+++ b/internal/powerbi/data_source_capacity_test.go
@@ -1,0 +1,32 @@
+package powerbi
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceCapacity_basic(t *testing.T) {
+	var capacityName = "Premium Per User - Reserved" // Using Capacity that always exists
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				data "powerbi_capacity" "test" {
+					name = "%s"
+				}
+				`, capacityName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.powerbi_capacity.test", "name", capacityName),
+					resource.TestCheckResourceAttrSet("data.powerbi_capacity.test", "id"),
+					resource.TestCheckResourceAttrSet("data.powerbi_capacity.test", "sku"),
+					resource.TestCheckResourceAttrSet("data.powerbi_capacity.test", "region"),
+				),
+			},
+		},
+	})
+}

--- a/internal/powerbi/provider.go
+++ b/internal/powerbi/provider.go
@@ -53,6 +53,7 @@ func Provider() *schema.Provider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"powerbi_workspace": DataSourceWorkspace(),
+			"powerbi_capacity":  DataSourceCapacity(),
 		},
 
 		ConfigureFunc: providerConfigure,


### PR DESCRIPTION
This is really https://github.com/codecutout/terraform-provider-powerbi/pull/33 just with a `break`

### In case you need something now

**Note:** Example below does NOT handle pagination but if you only have a few capacities this can keep you going

```hcl
terraform {
  required_providers {
    http = {
      source  = "hashicorp/http"
      version = "3.4.0"
    }
    oauth = {
      source  = "SvenHamers/oauth"
      version = "1.6.7"
    }
  }
}

provider "oauth" {}

data "oauth_token" "powerbi" {
  client_id      = "<client_id as powerbi provider>"
  client_secret  = "<client_secret as powerbi provider>"
  token_endpoint = "https://login.microsoftonline.com/<tenant id as powerbi provider>/oauth2/v2.0/token"
  scopes         = ["https://analysis.windows.net/powerbi/api/.default"]
}

data "http" "capacities" {
  method     = "GET"
  url        = "https://api.powerbi.com/v1.0/myorg/capacities"

  request_headers = {
    Authorization = "Bearer ${data.oauth_token.powerbi.token}"
  }
}

locals {
  capacities = {
    for capacity in jsondecode(data.http.capacities.response_body)["value"] :
    capacity.displayName => {
      id                      = capacity.id
      state                   = capacity.state
      capacityUserAccessRight = capacity.capacityUserAccessRight
    }
  }
  myCapacity = local.capacities["Premium Per User - Reserved"]
}
```